### PR TITLE
Fix name on setter and deleter property

### DIFF
--- a/docs/correctness/implementing_java-style_getters_and_setters.rst
+++ b/docs/correctness/implementing_java-style_getters_and_setters.rst
@@ -68,11 +68,11 @@ When a member needs to be slightly protected and cannot be simply exposed as a p
         def length(self):
             return self._length
 
-        @width.setter
+        @length.setter
         def length(self, value):
             self._length = value
         
-        @width.deleter
+        @length.deleter
         def length(self):
             del self._length
 


### PR DESCRIPTION
The setter and deleter properties used the name "width" when they were actually working on length