### PR TITLE
Update returning_more_than_one_variable_type_from_function_call.rst

### DIFF
--- a/docs/maintainability/returning_more_than_one_variable_type_from_function_call.rst
+++ b/docs/maintainability/returning_more_than_one_variable_type_from_function_call.rst
@@ -21,10 +21,10 @@ In the code below, the function ``get_secret_code()`` returns a secret code when
 
     secret_code = get_secret_code("unicycle")
 
-    if secret_code == None:
-        print "Wrong password."
+    if secret_code is None:
+        print("Wrong password.")
     else:
-        print "The secret code is {}".format(secret_code)
+        print("The secret code is {}".format(secret_code))
         
 
 Solutions
@@ -45,6 +45,6 @@ When a calling code provides invalid data to a function, or a precondition to th
 
     try:
         secret_code = get_secret_code("unicycle")
-        print "The secret code is {}".format(secret_code)
+        print("The secret code is {}".format(secret_code))
     except ValueError:
-        print "Wrong password."
+        print("Wrong password.")


### PR DESCRIPTION
Fixed example code

* print statement -> print "function" (not really a function if in Python2 but makes the code forward compatible)
* var == None -> var is None