### PR TITLE
Update not_using_zip_to_iterate_over_a_pair_of_lists.rst

### DIFF
--- a/docs/readability/not_using_zip_to_iterate_over_a_pair_of_lists.rst
+++ b/docs/readability/not_using_zip_to_iterate_over_a_pair_of_lists.rst
@@ -36,3 +36,4 @@ References
 ----------
 
 - `PEP 20 - The Zen of Python <http://legacy.python.org/dev/peps/pep-0020/>`_
+- `Built-in Functions > zip(*iterables) <https://docs.python.org/3.4/library/functions.html#zip>`_


### PR DESCRIPTION
Add reference to `zip` function as there's some useful trick there.