### PR TITLE
Modify items() to iteritems()

### DIFF
--- a/docs/readability/not_using_items_to_iterate_over_a_dictionary.rst
+++ b/docs/readability/not_using_items_to_iterate_over_a_dictionary.rst
@@ -1,5 +1,5 @@
-Not using ``items()`` to iterate over a dictionary
-==================================================
+Not using ``iteritems()`` to iterate over a dictionary
+======================================================
 
 `PEP 20 <http://legacy.python.org/dev/peps/pep-0020/>`_ states "There should be one-- and preferably only one --obvious way to do it." The preferred way to iterate over the key-value pairs of a dictionary is to declare two variables in a for loop, and then call ``dictionary.items()``, where ``dictionary`` is the name of your variable representing a dictionary. For each loop iteration, Python will automatically assign the first variable as the key and the second variable as the value for that key.
 
@@ -18,19 +18,30 @@ The code below defines a for loop that iterates over a dictionary named ``d``. F
 Best-practice
 -------------
 
-Use ``items()`` to iterate across dictionary
-............................................
+Use ``iteritems()`` to iterate across dictionary
+................................................
 
-The updated code below demonstrates the Pythonic style for iterating through a dictionary. When you define two variables in a ``for`` loop in conjunction with a call to ``items()`` on a dictionary, Python automatically assigns the first variable as the name of a key in that dictionary, and the second variable as the corresponding value for that key.
+The updated code below demonstrates the Pythonic style for iterating through a dictionary. When you define two variables in a ``for`` loop in conjunction with a call to ``iteritems()`` on a dictionary, Python automatically assigns the first variable as the name of a key in that dictionary, and the second variable as the corresponding value for that key.
 
 .. code:: python
 
     d = {"first_name": "Alfred", "last_name":"Hitchcock"}
     
-    for key,val in d.items():
+    for key,val in d.iteritems():
         print "{} = {}".format(key, val)
+
+``items()`` may be another choice to iterate a dictionary, but in fact, ``iteritems()`` is better.
+
+In Python 2, Python ``items()`` built a real list of tuples and returned that. That could potentially take a lot of extra memory.
+
+Then, generators were introduced to the language in general, and that method was reimplemented as a iterator-generator method named ``iteritems()``.
+
+In Python 3,the ``iteritems()`` is gone, instead, the ``items()`` returns an iterator just like how ``iteritems()`` works in Python 2.
+
+So if you work with Python 2, ``iteritems()`` is the best choice,and if you work with Python 3, you can only use ``items()``, you have no other choice. 
 
 References
 ----------
 
 - `PEP 20 - The Zen of Python <http://legacy.python.org/dev/peps/pep-0020/>`_
+- `What is the difference between dict.items() and dict.iteritems()?     <http://stackoverflow.com/questions/10458437/what-is-the-difference-between-dict-items-and-dict-iteritems>`_


### PR DESCRIPTION
Use  `iteritems()`  to iterate a dict may be better than using `items()`, please read the reference which I add and make sure that my modification is correct.
I'm sorry about that I'm not familiar with the syntax of the reStructuredText(I often use markdown to write docs ), so please check my commit carefully.
By the way, thanks, this little book is helpful.