### PR TITLE
Use proper slashes

### DIFF
--- a/docs/django/all/correctness/not_using_forward_slashes.rst
+++ b/docs/django/all/correctness/not_using_forward_slashes.rst
@@ -18,7 +18,7 @@ This pattern is exemplary for any of the above mentioned settings. It uses backs
     """ settings.py """
 
     STATICFILES_DIRS = [
-        "\path\to\my\static\files",
+        "\\path\\to\\my\\static\\files",
     ]
 
 Best practice
@@ -31,7 +31,7 @@ Django requires you to use forward slashes ``/``, even on Windows.
     """ settings.py """
 
     STATICFILES_DIRS = [
-        "\path\to\my\static\files",
+        "/path/to/my/static/files",
     ]
 
 References


### PR DESCRIPTION
Backslashes need to be escaped. Use forward slashes, as mentioned, in the best practice code sample.