### PR TITLE
Update iteration example

### DIFF
--- a/examples/new_patterns.py
+++ b/examples/new_patterns.py
@@ -72,7 +72,7 @@ while i < 10:
     #we forget to increment i
 
 """
-Not using .items() to iterate over a list of key/value pairs of a dictionary.
+Not using .iteritems() to iterate over a list of key/value pairs of a dictionary.
 """
 
 #Bad
@@ -85,7 +85,7 @@ for key in d:
 
 #Good
 
-for key,value in d.items():
+for key,value in d.iteritems():
     print "%s = %d" % (key,value)
 
 """


### PR DESCRIPTION
Use `iteritems()` instead of `items()` to iterate over a list. Better memory footprint since it uses an Iterator object instead of creating a new list. This is the default behaviour for `items()` in Python 3.x. 

See https://docs.python.org/2/library/stdtypes.html#dict.iteritems