### PR TITLE
Fix "mutable default values" code samples

### DIFF
--- a/docs/correctness/mutable_default_value_as_argument.rst
+++ b/docs/correctness/mutable_default_value_as_argument.rst
@@ -37,9 +37,9 @@ If, like the programmer who implemented the ``append`` function above, you want 
         print number_list
         return number_list
 
-    append(5, None) # expecting: [5], actual: [5]
-    append(7, None) # expecting: [7], actual: [7]
-    append(2, None) # expecting: [2], actual: [2]
+    append(5) # expecting: [5], actual: [5]
+    append(7) # expecting: [7], actual: [7]
+    append(2) # expecting: [2], actual: [2]
 
 References
 ----------

--- a/docs/correctness/mutable_default_value_as_argument.rst
+++ b/docs/correctness/mutable_default_value_as_argument.rst
@@ -10,10 +10,10 @@ A programmer wrote the ``append`` function below under the assumption that the `
 
 .. code:: python
 
-    def append(number, list=[]):
-        list.append(number)
-        print list
-        return list
+    def append(number, number_list=[]):
+        number_list.append(number)
+        print number_list
+        return number_list
 
     append(5) # expecting: [5], actual: [5]
     append(7) # expecting: [7], actual: [5, 7]
@@ -30,12 +30,12 @@ If, like the programmer who implemented the ``append`` function above, you want 
 
 .. code:: python
 
-    def append(number, list=None): # the keyword None is the sentinel value representing empty list
-        if list is None:
-            list = []
-        list.append(number)
-        print list
-        return list
+    def append(number, number_list=None): # the keyword None is the sentinel value representing empty list
+        if number_list is None:
+            number_list = []
+        number_list.append(number)
+        print number_list
+        return number_list
 
     append(5, None) # expecting: [5], actual: [5]
     append(7, None) # expecting: [7], actual: [7]


### PR DESCRIPTION
Two minor issues with the "Using a mutable default value as an argument" chapter:

1. The list variable shouldn't be named "list".
2. The sentinel value shouldn't be passed into the `append` function in the second example.  It's not incorrect, but this chapter is all about default values.