### PR TITLE
Mention Pylint's symbolic names along with message ids

### DIFF
--- a/docs/correctness/accessing_a_protected_member_from_outside_the_class.rst
+++ b/docs/correctness/accessing_a_protected_member_from_outside_the_class.rst
@@ -29,7 +29,7 @@ do the following:
 References
 ----------
 
-- PyLint - W0212
+- PyLint - W0212, protected-access
 
 Status
 ------

--- a/docs/correctness/bad_except_clauses_order.rst
+++ b/docs/correctness/bad_except_clauses_order.rst
@@ -37,7 +37,7 @@ The modified code below places the ``ZeroDivisionError`` exception clause in fro
 References
 ----------
 
-- Pylint - E0701
+- Pylint - E0701, bad-except-order
 
 Status
 ------

--- a/docs/correctness/bad_first_argument_given_to_super.rst
+++ b/docs/correctness/bad_first_argument_given_to_super.rst
@@ -54,7 +54,7 @@ References
 - `Python Standard Library - super([type[, object-or-type]]) <https://docs.python.org/3.1/library/functions.html#super>`_
 - `Stack Overflow - What is a basic example of single inheritance using super()? <http://stackoverflow.com/questions/1173992/what-is-a-basic-example-of-single-inheritance-using-the-super-keyword-in-pytho>`_
 - `Stack Overflow - Python super() inheritance and arguments needed <http://stackoverflow.com/questions/15896265/python-super-inheritance-and-arguments-needed>`_
-- PyLint - E1003
+- PyLint - E1003, bad-super-call
 
 Status
 ------

--- a/docs/correctness/else_clause_on_loop_without_a_break_statement.rst
+++ b/docs/correctness/else_clause_on_loop_without_a_break_statement.rst
@@ -45,7 +45,7 @@ If the ``else`` clause should not always execute at the end of a loop clause, th
 References
 ----------
 
-- PyLint - W0120
+- PyLint - W0120, useless-else-on-loop
 - `Python Standard Library - else Clauses on Loops <https://docs.python.org/2/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops>`_
 
 Status

--- a/docs/correctness/exit_must_accept_three_arguments.rst
+++ b/docs/correctness/exit_must_accept_three_arguments.rst
@@ -84,7 +84,7 @@ Modifying ``__exit__`` to accept four arguments ensures that ``__exit__`` is pro
 References
 ----------
 
-- `PyLint - E0235 <https://docs.python.org/2/reference/datamodel.html#with-statement-context-managers>`_
+- PyLint - E0235,unexpected-special-method-signature
 - `Python Language Reference - The with statement <https://docs.python.org/2/reference/compound_stmts.html#with>`_
 - `Python Language Reference - With Statement Context Managers <https://docs.python.org/2/reference/datamodel.html#with-statement-context-managers>`_
 - `Stack Overflow - Python with...as <http://stackoverflow.com/a/14776885/1669860>`_

--- a/docs/correctness/explicit_return_in_init.rst
+++ b/docs/correctness/explicit_return_in_init.rst
@@ -56,7 +56,7 @@ Note that the class must inherit from ``object`` now, since the ``property`` dec
 References
 ----------
 
-- `PyLint - E0101 <http://pylint-messages.wikidot.com/messages:e0101>`_
+- PyLint - E0101, return-in-init
 - `Python Language Reference - object.__init__(self[, ...]) <https://docs.python.org/2/reference/datamodel.html#object.__init__>`_
 
 

--- a/docs/correctness/future_import_is_not_the_first_statement.rst
+++ b/docs/correctness/future_import_is_not_the_first_statement.rst
@@ -44,7 +44,7 @@ In the modified code below, the author decides that the module needs the new fun
 References
 ----------
 
-- PyLint - W0410
+- PyLint - W0410, misplaced-future
 - `Simeon Visser - How does 'from __future__ import ...' work? <http://simeonvisser.com/posts/how-does-from-future-import-work-in-python.html>`_
 - `Python Standard Library - __future__ <https://docs.python.org/2/library/__future__.html>`_
 

--- a/docs/correctness/method_could_be_a_function.rst
+++ b/docs/correctness/method_could_be_a_function.rst
@@ -70,7 +70,8 @@ All class methods must be preceded by the ``@classmethod`` decorator. Furthermor
 
 References
 ----------
-- `PyLint - R0201 <http://pylint-messages.wikidot.com/messages:r0201>`_
+
+- PyLint - R0201, no-self-use
 
 
 Status

--- a/docs/correctness/method_has_no_argument.rst
+++ b/docs/correctness/method_has_no_argument.rst
@@ -85,7 +85,7 @@ If the method is a static method that does not need access to any instance membe
 
 References
 ----------
-- `PyLint - E0211 <http://pylint-messages.wikidot.com/messages:e0211>`_
+- PyLint - E0211, no-method-argument
 
 
 Status

--- a/docs/correctness/missing_argument_to_super.rst
+++ b/docs/correctness/missing_argument_to_super.rst
@@ -53,7 +53,7 @@ In the modified code below the author has fixed the call to ``super()`` so that 
 References
 ----------
 
-- PyLint - E1004
+- PyLint - E1004, missing-super-argument
 - `Python Standard Library - super([type[, object-or-type]]) <https://docs.python.org/3.1/library/functions.html#super>`_
 - `Stack Overflow - What is a basic example of single inheritance using super()? <http://stackoverflow.com/questions/1173992/what-is-a-basic-example-of-single-inheritance-using-the-super-keyword-in-pytho>`_
 - `Stack Overflow - Python super() inheritance and arguments needed <http://stackoverflow.com/questions/15896265/python-super-inheritance-and-arguments-needed>`_

--- a/docs/correctness/mutable_default_value_as_argument.rst
+++ b/docs/correctness/mutable_default_value_as_argument.rst
@@ -44,7 +44,7 @@ If, like the programmer who implemented the ``append`` function above, you want 
 References
 ----------
 
-- `PyLint - W0102 <http://pylint-messages.wikidot.com/messages:w0102>`_
+- PyLint - W0102, dangerous-default-value
 - `Stack Overflow - Hidden Features of Python <http://stackoverflow.com/questions/101268/hidden-features-of-python#113198>`_
 
 Status

--- a/docs/correctness/no_exception_type_specified.rst
+++ b/docs/correctness/no_exception_type_specified.rst
@@ -78,7 +78,7 @@ In addition to Python's standard exceptions, you can implement your own exceptio
 References
 ----------
 
-- `PyLint W0702<http://pylint-messages.wikidot.com/messages:w0702>`
+- PyLint W0702, bare-except
 - `Python Built-in Exceptions<https://docs.python.org/2/library/exceptions.html#exceptions.BaseException>`
 - `Python Errors and Exceptions<https://docs.python.org/2/tutorial/errors.html>`
 

--- a/docs/maintainability/using_the_global_statement.rst
+++ b/docs/maintainability/using_the_global_statement.rst
@@ -66,7 +66,7 @@ References
 ----------
 
 - `Cunningham & Cunningham, Inc. - Global Variables Are Bad <http://c2.com/cgi/wiki?GlobalVariablesAreBad>`_
-- PyLint - W0603
+- PyLint - W0603, global-statement
 
 Status
 ------

--- a/docs/readability/using_map_or_filter_where_list_comprehension_is_possible.rst
+++ b/docs/readability/using_map_or_filter_where_list_comprehension_is_possible.rst
@@ -29,7 +29,7 @@ In the modified code below, the code uses a list comprehension to generate the s
 References
 ----------
 
-- PyLint - W0110
+- PyLint - W0110, deprecated-lambda
 - `Oliver Fromme - List Comprehensions <http://www.secnetix.de/olli/Python/list_comprehensions.hawk>`_
 
 Status

--- a/docs/security/use_of_exec.rst
+++ b/docs/security/use_of_exec.rst
@@ -35,7 +35,7 @@ In most scenarios, you can easily refactor the code to avoid the use of ``exec``
 References
 ----------
 
-- `PyLint - W0122 <http://pylint-messages.wikidot.com/messages:w0122>`_
+- PyLint - W0122, exec-used
 - `Python Language Reference - The exec statement <https://docs.python.org/2/reference/simple_stmts.html#the-exec-statement>`_
 - `Stack Overflow - Why should exec() and eval() be avoided? <http://stackoverflow.com/questions/1933451/why-should-exec-and-eval-be-avoided>`_
 


### PR DESCRIPTION
Hi,

A small Pylint related issue.

We're trying to move away from using numeric message ids for errors and warnings, since they can not be easily remembered, slowly becoming a second class citizen. Instead, Pylint uses symbolic names, which don't carry as much information as the numerical ids (from what checker they're coming for instance), but they can be remembered easily and carry a semantic meaning due to their natural language expressiveness.

Also, this patch removes the mentions to wikidot, since it's not sanctioned by Pylint as an official source of documentation, its use being an artifact from Pylint's past.