### PR TITLE
Fix typo 'in' -> 'is'

### DIFF
--- a/docs/readability/test_for_object_identity_should_be_is_not.rst
+++ b/docs/readability/test_for_object_identity_should_be_is_not.rst
@@ -1,7 +1,7 @@
 Test for object identity should be ``is``
 ========================================
 
-Testing the identity of two objects can be achieved in python with a special operator called ``in``.
+Testing the identity of two objects can be achieved in python with a special operator called ``is``.
 Most prominently it is used to check whether an variable points to ``None``.
 But the operator can examine any kind of identity.
 This often leads to confusion because equality of two different objects will return ``False``.


### PR DESCRIPTION
In general, the wording in this article could be a bit better, but I'll just correct the one glaring typo for now.