### PR TITLE
Test for membership should be "not in"

### DIFF
--- a/docs/correctness/not_using_defaultdict.rst
+++ b/docs/correctness/not_using_defaultdict.rst
@@ -12,7 +12,7 @@ The code below defines an empty dict and then manually initializes the keys of t
 
     d = {}
 
-    if not "k" in d:
+    if "k" not in d:
         d["k"] = 6
 
     d["k"] += 1


### PR DESCRIPTION
A linter would yeild an error on the anti-pattern code.  Even though it
is anti-pattern code, it should demonstrate best practices for
everything except the anti-pattern being demonstrated.

Although `not 'k' in d` and `'k' not in d` ultimately produce the same
bytecode, the former is actually two operations and must be optimized to
produce identical bytecode to the latter.

The preferred syntax would be `'k' not in d` - per the pep8/flake8
linter.

References:

 - https://github.com/PyCQA/pycodestyle/blob/1.7.0/pep8.py#L1077-L1078
 - http://stackoverflow.com/questions/17659303/what-is-more-pythonic-for-not