### PR TITLE
Fix title emphasis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#The Little Book of Python Anti-Patterns
+# The Little Book of Python Anti-Patterns
 
 This is an open-source book of **Python anti-patterns and worst practices**. Check out `docs/index.rst` for more information.
 
 **Notice**: This is still (and will always be) a work-in-progress, feel free to contribute by suggesting improvements, adding new articles, improving existing ones, or translating this into other languages.
 
-# New articles
+## New articles
 If you add new articles, please use the provided templates. Depending on the pattern you are creating, use either the [anti-pattern](templates/anti_pattern.rst) or the [migration-pattern](templates/migration_pattern.rst) template.
 
-#License
+## License
 
 The book is made available under a Creative Commons Attribution-Non-Commercial-ShareAlike 4.0 license. This allows you to use and distribute it freely for your own non-commercial projects (e.g. for teaching) if you make your contributions available under the same license.
 


### PR DESCRIPTION
Currently the headers are not generated properly. Markdown requires a space between the hash symbol (`#`) and the header text. This commit will add the spaces and thus allow proper header generation. It will also reduce the header level for the subtitles to h2.

Before:

![Before](https://user-images.githubusercontent.com/24862378/32691632-a94a4b7c-c702-11e7-8e34-e73cc3d2f0e7.png)

After:

![After](https://user-images.githubusercontent.com/24862378/32691641-b9b95ffc-c702-11e7-9a76-1d0d0b109c2c.png)

