### PR TITLE
Make the Python 2 aspect more visible

### DIFF
--- a/docs/performance/not_using_iteritems_to_iterate_large_dict.rst
+++ b/docs/performance/not_using_iteritems_to_iterate_large_dict.rst
@@ -1,9 +1,9 @@
-Not using ``iteritems()`` to iterate over a large dictionary
-============================================================
+Not using ``iteritems()`` to iterate over a large dictionary in Python 2
+========================================================================
 
 `PEP 234 <https://www.python.org/dev/peps/pep-0234://www.python.org/dev/peps/pep-0234/>`_ defines iteration interface for objects. It also states it has significant impact on performance of dict iteration.
 
-.. note:: This anti-pattern only applies to Python versions 2.x. In Python 3.x ``items()`` returns an iterator (consequently, ``iteritems()`` has been removed from Python 3.x).
+.. note:: This anti-pattern only applies to Python versions 2.x. In Python 3.x ``items()`` returns an iterator (consequently, ``iteritems()`` and Python 2's iterative ``range()`` function, ``xrange()``, have been removed from Python 3.x).
 
 
 Anti-pattern


### PR DESCRIPTION
* Add Python 2 to the heading.
* Mention that ``xrange()`` is Python 2 only, too.
* Fixes issue #43