### PR TITLE
Don't assign to in-built function in example

### DIFF
--- a/docs/correctness/else_clause_on_loop_without_a_break_statement.rst
+++ b/docs/correctness/else_clause_on_loop_without_a_break_statement.rst
@@ -10,8 +10,8 @@ The code below demonstrates some potential unintended behavior that can result w
 
 .. code:: python
 
-    def contains_magic_number(list, magic_number):
-        for i in list:
+    def contains_magic_number(numbers, magic_number):
+        for i in numbers:
             if i == magic_number:
                 print("This list contains the magic number")
         else:
@@ -31,8 +31,8 @@ If the ``else`` clause should not always execute at the end of a loop clause, th
 
 .. code:: python
 
-    def contains_magic_number(list, magic_number):
-        for i in list:
+    def contains_magic_number(numbers, magic_number):
+        for i in numbers:
             if i == magic_number:
                 print("This list contains the magic number.")
                 # added break statement here


### PR DESCRIPTION
Here we assign to the variable `list`, which goes against http://docs.quantifiedcode.com/python-anti-patterns/correctness/assigning_to_builtin.html.

In this example it doesn't break anything, but better to be safe than sorry?