### PR TITLE
Updated to include case of single element list

### DIFF
--- a/docs/correctness/not_using_explicit_unpacking.rst
+++ b/docs/correctness/not_using_explicit_unpacking.rst
@@ -31,3 +31,28 @@ The modified code below is functionally equivalent to the original code, but thi
     elem0, elem1, elem2 = elems
 
 
+Anti-pattern
+------------
+
+Indexing [0] to extract a single data structure nested in a list. It is not clear why the first element is being indexed.
+
+.. code:: python
+
+    data = [{"InstanceId": "i-1"}]
+
+    instance = data[0]
+
+
+Best practice
+-------------
+
+Use unpacking
+.............
+
+The modified code below is functionally equivalent but is explicit.
+
+.. code:: python
+
+    data = [{"InstanceId": "i-1"}]
+
+    instance, = data


### PR DESCRIPTION
Indexing[0] to extract an element nested in a list occurs frequently in code handling JSON and is an extension of this anti-pattern