### PR TITLE
f-string substitutions

### DIFF
--- a/docs/correctness/accessing_a_protected_member_from_outside_the_class.rst
+++ b/docs/correctness/accessing_a_protected_member_from_outside_the_class.rst
@@ -16,7 +16,7 @@ Anti-pattern
 
     r = Rectangle(5, 6)
     # direct access of protected member
-    print("Width: {:d}".format(r._width))
+    print(f"Width: {r._width}")
 
 Best practice
 -------------

--- a/docs/correctness/method_could_be_a_function.rst
+++ b/docs/correctness/method_could_be_a_function.rst
@@ -69,7 +69,7 @@ All class methods must be preceded by the ``@classmethod`` decorator. Furthermor
         @classmethod
         def print_class_name(cls):
             # "class name: Rectangle"
-            print("class name: {0}".format(cls))
+            print(f"class name: {cls}")
 
 References
 ----------

--- a/docs/correctness/method_has_no_argument.rst
+++ b/docs/correctness/method_has_no_argument.rst
@@ -32,7 +32,7 @@ The method ``print_class_name`` attempts to print the name of the class. However
         # missing first argument "cls"
         def print_class_name():
             # cls is undefined here
-            print("Hello, I am {0}!".format(cls))
+            print(f"Hello, I am {cls}!")
 
 
 The method ``area`` computes the value of any rectangle. Currently this method is ambiguous. It is defined as a method of the ``Rectangle`` class, yet it does not reference any instance or class members. The method needs to explicitly state that it is a static method via the ``@staticmethod`` decorator.
@@ -74,7 +74,7 @@ To access the name of the class the ``print_class_name`` method needs to explici
         @classmethod
         # class members now accessible, thanks to "cls"
         def print_class_name(cls):
-            print("Hello, I am {0}!".format(cls))
+            print(f"Hello, I am {cls}!")
 
 Add the ``@staticmethod`` decorator to static methods
 ........................................................

--- a/docs/correctness/no_exception_type_specified.rst
+++ b/docs/correctness/no_exception_type_specified.rst
@@ -34,10 +34,10 @@ Handle exceptions with Python's built in `exception types <https://docs.python.o
             print("Type error: division by 0.")
         except TypeError:
             # E.g., if b is a string
-            print("Type error: division by '{0}'.".format(b))
+            print(f"Type error: division by '{b}'.")
         except Exception as e:
             # handle any other exception
-            print("Error '{0}' occured. Arguments {1}.".format(e.message, e.args))
+            print(f"Error '{e.message}' occured. Arguments {e.args}.")
         else:
             # Excecutes if no exception occured
             print("No errors")

--- a/docs/maintainability/returning_more_than_one_variable_type_from_function_call.rst
+++ b/docs/maintainability/returning_more_than_one_variable_type_from_function_call.rst
@@ -24,7 +24,7 @@ In the code below, the function ``get_secret_code()`` returns a secret code when
     if secret_code is None:
         print("Wrong password.")
     else:
-        print("The secret code is {}".format(secret_code))
+        print(f"The secret code is {secret_code}")
 
 
 
@@ -46,7 +46,7 @@ When invalid data is provided to a function, a precondition to a function is not
 
     try:
         secret_code = get_secret_code("unicycle")
-        print("The secret code is {}".format(secret_code))
+        print(f"The secret code is {secret_code}")
     except ValueError:
         print("Wrong password.")
 

--- a/docs/performance/not_using_iteritems_to_iterate_large_dict.rst
+++ b/docs/performance/not_using_iteritems_to_iterate_large_dict.rst
@@ -17,7 +17,7 @@ The code below defines one large dictionary (created with dictionary comprehensi
 
     # Slow and memory hungry.
     for key, value in d.items():
-        print("{0} = {1}".format(key, value))
+        print(f"{key} = {value}")
 
 Best-practice
 -------------
@@ -33,7 +33,7 @@ The updated code below uses ``iteritems()`` instead of ``items()`` method. Note 
 
     # Memory efficient.
     for key, value in d.iteritems():
-        print("{0} = {1}".format(key, value))
+        print(f"{key} = {value}")
 
 References
 ----------

--- a/docs/readability/not_using_items_to_iterate_over_a_dictionary.rst
+++ b/docs/readability/not_using_items_to_iterate_over_a_dictionary.rst
@@ -13,7 +13,7 @@ The code below defines a for loop that iterates over a dictionary named ``d``. F
     d = {"first_name": "Alfred", "last_name":"Hitchcock"}
 
     for key in d:
-        print("{} = {}".format(key, d[key]))
+        print(f"{key} = {d[key]}")
 
 Best-practice
 -------------
@@ -28,7 +28,7 @@ The updated code below demonstrates the Pythonic style for iterating through a d
     d = {"first_name": "Alfred", "last_name":"Hitchcock"}
 
     for key,val in d.items():
-        print("{} = {}".format(key, val))
+        print(f"{key} = {val}")
 
 Difference Python 2 and Python 3
 --------------------------------

--- a/examples/new_patterns.py
+++ b/examples/new_patterns.py
@@ -81,12 +81,12 @@ d = {'foo' : 1,'bar' : 2}
 
 for key in d:
     value = d[key]
-    print("%s = %d" % (key,value))
+    print(f"{key} = {value}")
 
 #Good
 
 for key,value in d.iteritems():
-    print("%s = %d" % (key,value))
+    print(f"{key} = {value}")
 
 """
 Not using zip() to iterate over a pair of lists
@@ -386,7 +386,7 @@ s = "there were "+str(n_errors)+" errors."
 
 #Good
 
-s = "there were %d errors." % n_errors
+s = f"there were {n_errors} errors."
 
 """
 Putting type information in the variable name (Hungarian notation)


### PR DESCRIPTION
Updated examples in favor of more readable f-strings over format.

[PEP 498](https://www.python.org/dev/peps/pep-0498/) available for Python 3.6 and later.