### PR TITLE
Adding the type error Python compiler will throw

### DIFF
--- a/docs/correctness/explicit_return_in_init.rst
+++ b/docs/correctness/explicit_return_in_init.rst
@@ -35,6 +35,12 @@ Remove the ``return`` statement in the ``__init__`` method that is returning a v
             self.area = width * height
             # return statement removed from here
 
+
+Note: Even if you set the return to anything different than ``None`` Python compiler will throw the error like this to prevent the explicit return:
+
+    TypeError: __init__() should return None, not '...'  
+
+
 Move the program logic to another instance method
 .................................................
 


### PR DESCRIPTION
Recent Python compilers ( I checked Python 2.7, as well 3.6, and 3.7) will throw the specific error on explicit return other than ``None``.

You can check this with code like this
```
class C:
    def __init__(self):
        return 1
        
ci=C() #TypeError: __init__() should return None, not 'int'

```