### PR TITLE
Fix indent in code example

### DIFF
--- a/docs/correctness/indentation_contains_mixed_spaces_and_tabs.rst
+++ b/docs/correctness/indentation_contains_mixed_spaces_and_tabs.rst
@@ -11,7 +11,7 @@ The following code mixes spaces and tabs for indentation. The ``print("Hello, Wo
 .. code:: python
 
     def print_hello_world():
-    # indented with tab
+    	# indented with tab
 	print("Hello, World!")
     def print_goodbye_world():
         # indented with 4 spaces


### PR DESCRIPTION
Add a missing tab indentation to the comment. 

With this fix it will also match the indentation of the following example: https://docs.quantifiedcode.com/python-anti-patterns/correctness/indentation_contains_tabs.html 