### PR TITLE
Using type() - fix examples to work, and demonstrate the principle.

### DIFF
--- a/docs/readability/do_not_compare_types_use_isinstance.rst
+++ b/docs/readability/do_not_compare_types_use_isinstance.rst
@@ -23,26 +23,24 @@ The ``if`` statement below uses the pattern ``if type(OBJECT) is types.TYPE`` to
     if type(r) is types.ListType:
         print("object r is a list")
 
-Note that the following situation will not raise the error, although it should.
+Note that the following situation will raise the error, although it shouldn't.
 
 .. code:: python
-
-    import types
 
     class Rectangle(object):
         def __init__(self, width, height):
             self.width = width
             self.height = height
 
-    class Circle(object):
-        def __init__(self, radius):
-            self.radius = radius
+    class Square(Rectangle):
+        def __init__(self, length):
+            super(Square, self).__init__(length, length)
 
-    c = Circle(2)
     r = Rectangle(3, 4)
+    s = Square(2)
 
     # bad
-    if type(r) is not type(c):
+    if type(r) is not type(s):
         print("object types do not match")
 
 Best practice
@@ -55,18 +53,21 @@ The preferred pattern for comparing types is the built-in function ``isinstance`
 
 .. code:: python
 
-    import types
-
     class Rectangle(object):
         def __init__(self, width, height):
             self.width = width
             self.height = height
 
+    class Square(Rectangle):
+        def __init__(self, length):
+            super(Square, self).__init__(length, length)
+
     r = Rectangle(3, 4)
+    s = Square(2)
 
     # good
-    if isinstance(r, types.ListType):
-        print("object r is a list")
+    if isinstance(s, Rectangle):
+        print("object s is a Rectangle")
 
 References
 ----------


### PR DESCRIPTION
The existing example doesn't actually function as intended, and it doesn't really demonstrate the idea very well.

The reason stated for using `isinstance()` instead of comparing `type()`s is that `isinstance()` handles inheritance. So I'm not sure why the second example uses two unrelated classes `Rectangle` and `Circle`. The obvious choice is to use `Rectangle` and `Square`, as in this fix.

And I'm not sure what the idea was with the third example, either. The `Rectangle` object is not a `ListType`, and I'm not sure why one would think it is. So I changed it to be a repeat of the worst practice example, except using the best practice to compare.