### PR TITLE
readability/EAFP: update to Py 3, use specific exception, add race condition note

### DIFF
--- a/docs/readability/asking_for_permission_instead_of_forgiveness_when_working_with_files.rst
+++ b/docs/readability/asking_for_permission_instead_of_forgiveness_when_working_with_files.rst
@@ -16,13 +16,17 @@ The code below uses an ``if`` statement to check if a file exists before attempt
     if os.path.exists("file.txt"):
         os.unlink("file.txt")
 
+(Beyond coding style, the above code also has a potential race condition, as another program might delete the file between the ``exists`` and ``unlink`` calls.)
+
 Best practice
 -------------
 
 Assume the file can be used and catch problems as exceptions
 .............................................................
 
-The updated code below is a demonstration of the EAFP coding style, which is the preferred style in the Python community. Unlike the original code, the modified code below simply assumes that the needed file exists, and catches any problems as exceptions. For example, if the file does not exist, the problem will be caught as an ``OSError`` exception.
+The updated code below is a demonstration of the EAFP coding style, which is the preferred style in the Python community. Unlike the original code, the modified code below simply assumes that the needed file exists, and catches any problems as exceptions. For example, if the file does not exist, the problem will be reported as a ``FileNotFoundError`` exception.
+
+In Python 2, a plain ``OSError`` is raised instead (which can also result from other errors, e.g. permission issues).
 
 .. code:: python
 
@@ -31,12 +35,12 @@ The updated code below is a demonstration of the EAFP coding style, which is the
     try:
         os.unlink("file.txt")
     # raised when file does not exist
-    except OSError:
+    except FileNotFoundError: # or OSError, if using Python 2
         pass
 
 References
 ----------
 
-- `Python 2.7.8 - Glossary <https://docs.python.org/2/glossary.html>`_
+- `Python 3 - Glossary: EAFP <https://docs.python.org/3/glossary.html#term-eafp>`_
 
 


### PR DESCRIPTION
Add a note about the non-EAFP example code also having a potential race
condition (which is one of the reasons why the EAFP style is preferred).

Update best practice code to catch the specific FileNotFoundError (new
in Python 3.3), instead of the overly broad OSError. (Add note about
using OSError in Python 2, but caution that it may be too broad.)

Update glossary link to point to Python 3 docs, for good measure.