### PR TITLE
Fix typo, markup and PDF display issue. Fix Makefile latexpdf target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -125,9 +125,9 @@ latex:
 
 latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/html/python-anti-patterns/latex
-	@cp logo_qc.png $(BUILDDIR)/latex
+	@cp logo_qc.png $(BUILDDIR)/html/python-anti-patterns/latex
 	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	$(MAKE) -C $(BUILDDIR)/html/python-anti-patterns/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/html/python-anti-patterns/latex."
 
 latexpdfja:

--- a/docs/django/1.8/migration/template_string_if_invalid_deprecated.rst
+++ b/docs/django/1.8/migration/template_string_if_invalid_deprecated.rst
@@ -1,7 +1,7 @@
 TEMPLATE_STRING_IF_INVALID deprecated
 =====================================
 
-This setting sets the output that the template system should use for invalid (e.g. misspelled) variables. The default value is an empty string ``''``. This setting is deprecated since Django version 1.8. Set the `string_if_invalid` option in the `OPTIONS` of a `DjangoTemplates` backend instead.
+This setting sets the output that the template system should use for invalid (e.g. misspelled) variables. The default value is an empty string ``''``. This setting is deprecated since Django version 1.8. Set the ``string_if_invalid`` option in the ``OPTIONS`` of a ``DjangoTemplates`` backend instead.
 
 Deprecated feature
 ------------------

--- a/docs/django/all/performance/inefficient_database_queries.rst
+++ b/docs/django/all/performance/inefficient_database_queries.rst
@@ -47,7 +47,7 @@ Best practice
 Use ``.values()``
 .................
 
-To avoid such a scenario, make sure you only query the data you really need for your program. Use ``.values()`` to restrict the underlying SQL query to required fields only.
+To avoid such scenario, make sure you only query the data you really need. Use ``.values()`` to restrict the underlying SQL query to required fields only.
 
 .. code:: python
 

--- a/docs/django/all/security/allowed_hosts_setting_missing.rst
+++ b/docs/django/all/security/allowed_hosts_setting_missing.rst
@@ -19,7 +19,7 @@ Anti-Pattern
 Best practice
 -------------
 
-Make sure, an appropriate host is set in `ALLOWED_HOSTS`, whenever `DEBUG = False`.
+Make sure, an appropriate host is set in ``ALLOWED_HOSTS``, whenever ``DEBUG = False``.
 
 .. code:: python
 

--- a/docs/django/all/security/django_secrect_key_published.rst
+++ b/docs/django/all/security/django_secrect_key_published.rst
@@ -6,7 +6,7 @@ A secret key has to be be kept secret. Make sure it is only used in production, 
 Anti-pattern
 ------------
 
-This settings.py contains a SECRET_KEY. You should not do this!
+This settings.py contains a ``SECRET_KEY``. You should not do this!
 
 .. code:: python
 

--- a/docs/django/all/security/index.rst
+++ b/docs/django/all/security/index.rst
@@ -1,7 +1,7 @@
 :fa:`lock` Security
 ===================
 
-Most Django applications contain a lot of proprietory or even confidential information. Hence, it is crucial to take all possible measures to take your Django application secure and to recude the possibility of being hacked.
+Most Django applications contain a lot of proprietary or even confidential information. Hence, it is crucial to take all possible measures to take your Django application secure and to reduce the possibility of being hacked.
 
 Use the following patterns to increase the security of your code.
 

--- a/docs/django/all/security/same_value_for_media_root_and_static_root.rst
+++ b/docs/django/all/security/same_value_for_media_root_and_static_root.rst
@@ -1,7 +1,7 @@
 Same value for MEDIA_ROOT and STATIC_ROOT
 =========================================
 
-According to Django's documentation, ``MEDIA_ROOT`` and ``STATIC_ROOT`` must have different values. Before STATIC_ROOT was introduced, ``MEDIA_ROOT`` was also used (as fallback) to also serve static files. As this can have serious security implications, Django has validation checks to prevent it.
+According to Django's documentation, ``MEDIA_ROOT`` and ``STATIC_ROOT`` must have different values. Before ``STATIC_ROOT`` was introduced, ``MEDIA_ROOT`` was also used (as fallback) to also serve static files. As this can have serious security implications, Django has validation checks to prevent it.
 
 Anti-pattern
 ------------

--- a/docs/django/all/security/same_value_for_media_url_and_static_url.rst
+++ b/docs/django/all/security/same_value_for_media_url_and_static_url.rst
@@ -19,7 +19,7 @@ Anti-pattern
 Best practice
 -------------
 
-Ensure, `STATIC_URL` and `MEDIA_URL` point to different URL's.
+Ensure, ``STATIC_URL`` and ``MEDIA_URL`` point to different URL's.
 
 .. code:: python
 

--- a/docs/readability/test_for_object_identity_should_be_is_not.rst
+++ b/docs/readability/test_for_object_identity_should_be_is_not.rst
@@ -30,7 +30,7 @@ Only use the ``is`` operator if you want to check the exact identity of two refe
     some_list = None
 
     if some_list is None:
-        do_somthing_with_the_list()
+        do_something_with_the_list()
 
 References
 ----------


### PR DESCRIPTION
This PR fixes some typos and inconsistent markups, shortens the wording of a sentence to fix display issue on PDF: the dot of `.values()` is on previous line while `values()` is placed on the next line.

Edit: I also fixed the path in `latexpdf` target, now `make latexpdf` is enough, no need to go through my long list of steps in #102 