### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -189,7 +189,7 @@ latex_elements = {
 #'papersize': 'letterpaper',
 
 # Set font package
-# linux libertine needs this packafe installes on the machine
+# linux libertine needs this package installs on the machine
 # https://www.ctan.org/tex-archive/fonts/libertine/?lang=de
 # but should also be in the full installation of tex-live
 "fontpkg" : """

--- a/src/correctness/no_exception_type_specified.rst
+++ b/src/correctness/no_exception_type_specified.rst
@@ -37,9 +37,9 @@ Handle exceptions with Python's built in `exception types <https://docs.python.o
             print("Type error: division by '{0}'.".format(b))
         except Exception as e:
             # handle any other exception
-            print("Error '{0}' occured. Arguments {1}.".format(e.message, e.args))
+            print("Error '{0}' occurred. Arguments {1}.".format(e.message, e.args))
         else:
-            # Excecutes if no exception occured
+            # Excecutes if no exception occurred
             print("No errors")
         finally:
             # Executes always
@@ -50,7 +50,7 @@ Handle exceptions with Python's built in `exception types <https://docs.python.o
 
 With this pattern, you are able to handle exceptions based on their actual exception-type. The first exception type that matches the current error is handled first. Thus, it is recommended to handle specific exception types first (e.g., ZeroDivisionError) and generic error types (e.g., Exception) towards the end of the try-except block.
 
-**Cleanup actions (optional)**: The `else`-clause executes only, if no exception occurred. It is useful to log the success of your code. The `finally`-block executes under all circumstances — no matter if an error occured or not. It is useful to clean up the `try-except` block.
+**Cleanup actions (optional)**: The `else`-clause executes only, if no exception occurred. It is useful to log the success of your code. The `finally`-block executes under all circumstances — no matter if an error occurred or not. It is useful to clean up the `try-except` block.
 
 Implement user defined exceptions
 ---------------------------------

--- a/src/django/1.8/migration/index.rst
+++ b/src/django/1.8/migration/index.rst
@@ -1,7 +1,7 @@
 :fa:`magic` Migration to 1.8
 ===========================
 
-Migrating to a new Django version can be time consuming. To make this process easier, this chapter lists deprecated features and shows potential migration patterns/pathes.
+Migrating to a new Django version can be time consuming. To make this process easier, this chapter lists deprecated features and shows potential migration patterns/paths.
 
 .. toctree::
     :maxdepth: 1

--- a/src/django/all/security/index.rst
+++ b/src/django/all/security/index.rst
@@ -1,7 +1,7 @@
 :fa:`lock` Security
 ===================
 
-Most Django applications contain a lot of proprietory or even confidential information. Hence, it is crucial to take all possible measures to take your Django application secure and to recude the possibility of being hacked.
+Most Django applications contain a lot of proprietary or even confidential information. Hence, it is crucial to take all possible measures to take your Django application secure and to reduce the possibility of being hacked.
 
 Use the following patterns to increase the security of your code.
 

--- a/src/performance/not_using_iteritems_to_iterate_large_dict.rst
+++ b/src/performance/not_using_iteritems_to_iterate_large_dict.rst
@@ -9,7 +9,7 @@ Not using ``iteritems()`` to iterate over a large dictionary in Python 2
 Anti-pattern
 ------------
 
-The code below defines one large dictionary (created with dictionary comprehension) that generates large amounts of data. When using ``items()`` method, the iteration needs to be completed and stored in-memory before ``for`` loop can begin iterating. The prefered way is to use ``iteritems``. This uses (~1.6GB).
+The code below defines one large dictionary (created with dictionary comprehension) that generates large amounts of data. When using ``items()`` method, the iteration needs to be completed and stored in-memory before ``for`` loop can begin iterating. The preferred way is to use ``iteritems``. This uses (~1.6GB).
 
 .. code:: python
 

--- a/src/readability/not_using_a_dict_comprehension.rst
+++ b/src/readability/not_using_a_dict_comprehension.rst
@@ -33,6 +33,6 @@ The modified code below uses the new dict comprehension syntax which was introdu
 References
 ----------
 
-- `Stack Overflow - Create a dictionary with list comprehesion <http://stackoverflow.com/questions/1747817/python-create-a-dictionary-with-list-comprehension>`_
+- `Stack Overflow - Create a dictionary with list comprehension <http://stackoverflow.com/questions/1747817/python-create-a-dictionary-with-list-comprehension>`_
 
 

--- a/src/readability/not_using_dict_keys_when_formatting_strings.rst
+++ b/src/readability/not_using_dict_keys_when_formatting_strings.rst
@@ -1,7 +1,7 @@
 Not using dict keys when formatting strings
 ===========================================
 
-When formatting a string with values from a dictionary, you can use the dictionary keys instead of explicity defining all of the format parameters. Consider this dictionary that stores the name and age of a person.
+When formatting a string with values from a dictionary, you can use the dictionary keys instead of explicitly defining all of the format parameters. Consider this dictionary that stores the name and age of a person.
 
 
 .. code:: python

--- a/src/readability/putting_type_information_in_a_variable_name.rst
+++ b/src/readability/putting_type_information_in_a_variable_name.rst
@@ -22,7 +22,7 @@ Best practice
 Remove type notation
 ....................
 
-Although the modifed code below does not fix the underlying problem of attempting to divide a number by a string, the code is generally less misleading, because there is no misleading description in the variable name ``n`` that ``n`` is a number.
+Although the modified code below does not fix the underlying problem of attempting to divide a number by a string, the code is generally less misleading, because there is no misleading description in the variable name ``n`` that ``n`` is a number.
 
 .. code:: python
 


### PR DESCRIPTION
There are small typos in:
- src/conf.py
- src/correctness/no_exception_type_specified.rst
- src/django/1.8/migration/index.rst
- src/django/all/security/index.rst
- src/performance/not_using_iteritems_to_iterate_large_dict.rst
- src/readability/not_using_a_dict_comprehension.rst
- src/readability/not_using_dict_keys_when_formatting_strings.rst
- src/readability/putting_type_information_in_a_variable_name.rst

Fixes:
- Should read `reduce` rather than `recude`.
- Should read `proprietary` rather than `proprietory`.
- Should read `preferred` rather than `prefered`.
- Should read `paths` rather than `pathes`.
- Should read `package` rather than `packafe`.
- Should read `occurred` rather than `occured`.
- Should read `modified` rather than `modifed`.
- Should read `installs` rather than `installes`.
- Should read `explicitly` rather than `explicity`.
- Should read `comprehension` rather than `comprehesion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md