### PR TITLE
Issue 1086 Create pull-requests to python-anti-patterns with links to our docs 

### DIFF
--- a/docs/correctness/accessing_a_protected_member_from_outside_the_class.html
+++ b/docs/correctness/accessing_a_protected_member_from_outside_the_class.html
@@ -166,7 +166,7 @@ do the following:</p>
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - W0212, protected-access</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/protected-access.html">PyLint - W0212, protected-access</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/correctness/bad_except_clauses_order.html
+++ b/docs/correctness/bad_except_clauses_order.html
@@ -169,7 +169,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>Pylint - E0701, bad-except-order</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/error/bad-except-order.html">Pylint - E0701, bad-except-order</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/correctness/bad_first_argument_given_to_super.html
+++ b/docs/correctness/bad_first_argument_given_to_super.html
@@ -208,7 +208,7 @@
 <li><p><a class="reference external" href="https://docs.python.org/3.1/library/functions.html#super">Python Standard Library - super([type[, object-or-type]])</a></p></li>
 <li><p><a class="reference external" href="http://stackoverflow.com/questions/1173992/what-is-a-basic-example-of-single-inheritance-using-the-super-keyword-in-pytho">Stack Overflow - What is a basic example of single inheritance using super()?</a></p></li>
 <li><p><a class="reference external" href="http://stackoverflow.com/questions/15896265/python-super-inheritance-and-arguments-needed">Stack Overflow - Python super() inheritance and arguments needed</a></p></li>
-<li><p>PyLint - E1003, bad-super-call</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/error/bad-super-call.html">PyLint - E1003, bad-super-call</a></p></li>
 <li><p><a class="reference external" href="https://www.python.org/dev/peps/pep-3135/">PEP 3135 - New Super</a></p></li>
 </ul>
 </div>

--- a/docs/correctness/else_clause_on_loop_without_a_break_statement.html
+++ b/docs/correctness/else_clause_on_loop_without_a_break_statement.html
@@ -177,7 +177,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - W0120, useless-else-on-loop</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/useless-else-on-loop.html">PyLint - W0120, useless-else-on-loop</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops">Python Standard Library - else Clauses on Loops</a></p></li>
 </ul>
 </div>

--- a/docs/correctness/exit_must_accept_three_arguments.html
+++ b/docs/correctness/exit_must_accept_three_arguments.html
@@ -215,7 +215,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - E0235,unexpected-special-method-signature</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/error/unexpected-special-method-signature.html">PyLint - E0235,unexpected-special-method-signature</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/reference/compound_stmts.html#with">Python Language Reference - The with statement</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/reference/datamodel.html#with-statement-context-managers">Python Language Reference - With Statement Context Managers</a></p></li>
 <li><p><a class="reference external" href="http://stackoverflow.com/a/14776885/1669860">Stack Overflow - Python with…as</a></p></li>

--- a/docs/correctness/explicit_return_in_init.html
+++ b/docs/correctness/explicit_return_in_init.html
@@ -187,6 +187,7 @@
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
 <li><p>PyLint - E0101, return-in-init</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/error/return-in-init.html">PyLint - E0101, return-in-init</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/reference/datamodel.html#object.__init__">Python Language Reference - object.__init__(self[, …])</a></p></li>
 </ul>
 </div>

--- a/docs/correctness/future_import_is_not_the_first_statement.html
+++ b/docs/correctness/future_import_is_not_the_first_statement.html
@@ -175,7 +175,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - W0410, misplaced-future</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/misplaced-future.html">PyLint - W0410, misplaced-future</a></p></li>
 <li><p><a class="reference external" href="http://simeonvisser.com/posts/how-does-from-future-import-work-in-python.html">Simeon Visser - How does ‘from __future__ import …’ work?</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/library/__future__.html">Python Standard Library - __future__</a></p></li>
 </ul>

--- a/docs/correctness/method_could_be_a_function.html
+++ b/docs/correctness/method_could_be_a_function.html
@@ -197,7 +197,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - R0201, no-self-use</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/old-no-self-use.html">PyLint - R0201, no-self-use</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/correctness/method_has_no_argument.html
+++ b/docs/correctness/method_has_no_argument.html
@@ -214,7 +214,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - E0211, no-method-argument</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/error/no-method-argument.html">PyLint - E0211, no-method-argument</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/correctness/mutable_default_value_as_argument.html
+++ b/docs/correctness/mutable_default_value_as_argument.html
@@ -175,7 +175,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - W0102, dangerous-default-value</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/dangerous-default-value.html">PyLint - W0102, dangerous-default-value</a></p></li>
 <li><p><a class="reference external" href="http://stackoverflow.com/questions/101268/hidden-features-of-python#113198">Stack Overflow - Hidden Features of Python</a></p></li>
 </ul>
 </div>

--- a/docs/correctness/no_exception_type_specified.html
+++ b/docs/correctness/no_exception_type_specified.html
@@ -206,9 +206,9 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint W0702, bare-except</p></li>
-<li><p><cite>Python Built-in Exceptions&lt;https://docs.python.org/2/library/exceptions.html#exceptions.BaseException&gt;</cite></p></li>
-<li><p><cite>Python Errors and Exceptions&lt;https://docs.python.org/2/tutorial/errors.html&gt;</cite></p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/bare-except.html">PyLint W0702, bare-except</a></p></li>
+<li><p><a class="reference external" href="https://docs.python.org/2/library/exceptions.html#exceptions.BaseException">Python Built-in Exceptions</a></p></li>
+<li><p><a class="reference external" href="https://docs.python.org/2/tutorial/errors.html">Python Errors and Exceptions</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/maintainability/using_the_global_statement.html
+++ b/docs/maintainability/using_the_global_statement.html
@@ -178,7 +178,7 @@
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
 <li><p><a class="reference external" href="http://c2.com/cgi/wiki?GlobalVariablesAreBad">Cunningham &amp; Cunningham, Inc. - Global Variables Are Bad</a></p></li>
-<li><p>PyLint - W0603, global-statement</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/global-statement.html">PyLint - W0603, global-statement</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/security/use_of_exec.html
+++ b/docs/security/use_of_exec.html
@@ -144,7 +144,7 @@
 <div class="section" id="references">
 <h2>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
-<li><p>PyLint - W0122, exec-used</p></li>
+<li><p><a class="reference external" href="https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/exec-used.html">PyLint - W0122, exec-used</a></p></li>
 <li><p><a class="reference external" href="https://docs.python.org/2/reference/simple_stmts.html#the-exec-statement">Python Language Reference - The exec statement</a></p></li>
 <li><p><a class="reference external" href="http://stackoverflow.com/questions/1933451/why-should-exec-and-eval-be-avoided">Stack Overflow - Why should exec() and eval() be avoided?</a></p></li>
 </ul>


### PR DESCRIPTION
Got 13/15 missing links. However, I could not find documentation to link for these two so I left them alone:

1. PyLint - E1004, missing-super-argument from https://docs.quantifiedcode.com/python-anti-patterns/correctness/missing_argument_to_super.html

2. PyLint - W0110, deprecated-lambda from https://docs.quantifiedcode.com/python-anti-patterns/readability/using_map_or_filter_where_list_comprehension_is_possible.html